### PR TITLE
Remove rate limiter for rocksdb due to slow reloading

### DIFF
--- a/consensus/pow/ethash.go
+++ b/consensus/pow/ethash.go
@@ -484,7 +484,8 @@ func New(config Config, notify []string) *Ethash {
 		submitWorkCh: make(chan *mineResult),
 		fetchRateCh:  make(chan chan uint64),
 		submitRateCh: make(chan *hashrate),
-		exitCh:       make(chan chan error),
+		// Will block when Close is called
+		// exitCh:       make(chan chan error),
 	}
 	//go ethash.remote(notify)
 	return ethash

--- a/storage/rocksdb/database.go
+++ b/storage/rocksdb/database.go
@@ -25,10 +25,6 @@ type RDBDatabase struct {
 func New(dir string, applyOpts func(opts *rdb.Options)) (*RDBDatabase, error) {
 	// Create default options
 	opts := rdb.NewDefaultOptions()
-
-	// FIXME: set ratelimiter
-	ratelimiter := rdb.NewRateLimiter(1024, 100*1000, 10)
-	opts.SetRateLimiter(ratelimiter)
 	opts.SetCreateIfMissing(true)
 
 	if applyOpts != nil {


### PR DESCRIPTION
1. Use goprocess to organize go routines
2. Add signal handlers for interrupt
3. Remove rate limiter for rocksdb to speed up loading process