### PR TITLE
Feature/vm debug

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -89,11 +89,9 @@ func New(cfg *config.Config) (*Node, error) {
 	if txConfig.Journal != "" {
 		txConfig.Journal = cfg.ResolvePath(txConfig.Journal)
 	}
-	node.txPool = core.NewTxPool(txConfig, chainConfig, node.blockchain)
-	if cfg.Consensus.Mine {
-		node.miner = miner.New(chainConfig, node.blockchain, node.txPool, node.engine)
-	}
 
+	node.txPool = core.NewTxPool(txConfig, chainConfig, node.blockchain)
+	node.miner = miner.New(chainConfig, node.blockchain, node.txPool, node.engine)
 	node.network = impl.NewNetwork(cfg.Network, cfg.Dht, node.blockchain)
 
 	node.accman, node.ephemeralKeystore, err = config.MakeAccountManager(cfg)


### PR DESCRIPTION
修复bug：
在节点不挖矿启动后，调用eth_estimateGas等接口失败等问题。

逻辑上，就算节点不挖矿，不涉及区块链状态改变的一些操作，比如查询、统计某个调用花费gas等，也应该允许